### PR TITLE
[#32] Desacopla configurações de debug do Django

### DIFF
--- a/.github/workflows/project_CI.yml
+++ b/.github/workflows/project_CI.yml
@@ -22,6 +22,10 @@ jobs:
         pipenv sync --dev
         pipenv install codecov
 
+    - name: Cópia de variáveis de configurações para arquivo .env
+      run: |
+        cp contrib/env-sample .env
+
     - name: Lint com flake8
       run: |
         pipenv run flake8 --max-line-length=120 --exclude=.venv .

--- a/Django_DevPro/settings.py
+++ b/Django_DevPro/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 from pathlib import Path
+from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -23,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-(rc^uksfg08!i-oah_5-lbzzdw(8-d$tos#prw^u5@k67e3kx9'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', cast=bool)
 
 ALLOWED_HOSTS = ['*']
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 pipenv = "*"
 django = "*"
 gunicorn = "*"
+python-decouple = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aabcec095a56c55361f85701e6023f442d35bdf1f56ced5c2e77ff890cda6af1"
+            "sha256": "83e7b7a16ba3133a029e41186c826b88e8de597cdf519eab7b6657a836bbc33c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -93,6 +93,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.4.0"
+        },
+        "python-decouple": {
+            "hashes": [
+                "sha256:011d3f785367c54a72cf8a07d3a7a48bb8cc1a0f8e6c70353ca5767ebf7c8c9d",
+                "sha256:68e4b3fcc97e24bc90eecc514852d0bf970f4ff031f5f7a6728ddafa9afefcaf"
+            ],
+            "index": "pypi",
+            "version": "==3.5"
         },
         "pytz": {
             "hashes": [

--- a/contrib/env-sample
+++ b/contrib/env-sample
@@ -1,0 +1,1 @@
+DEBUG=False


### PR DESCRIPTION
Utiliza biblioteca "python-decouple" para usar diferentes configurações de debug para o Django a depender do local onde seu servidor está rodando. Torna função de debug do Django habilitada apenas quando servidor for rodado localmente.

Disponibiliza sample de arquivo de configuração de variável na pasta "contrib".

Configura o servidor de integração contínua para utilizar configuração presente no sample criado.

[Close #32]