### PR TITLE
[#37] Configura variável ALLOWED_HOSTS

### DIFF
--- a/Django_DevPro/settings.py
+++ b/Django_DevPro/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 from pathlib import Path
-from decouple import config
+from decouple import config, Csv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,7 +26,7 @@ SECRET_KEY = config('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', cast=bool)
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv())
 
 
 # Application definition

--- a/contrib/env-sample
+++ b/contrib/env-sample
@@ -1,2 +1,3 @@
 DEBUG=False
 SECRET_KEY=defina sua chave secreta
+ALLOWED_HOSTS=127.0.0.1


### PR DESCRIPTION
Utiliza biblioteca python-decouple para settar diferentes valores para a variável dependendo do ambiente onde o servidor está sendo rodado.

[Close #37]