### PR TITLE
[#47] Configura coleta de arquivos estáticos e upload de arquivos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/staticfiles/

--- a/Django_DevPro/settings.py
+++ b/Django_DevPro/settings.py
@@ -122,6 +122,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'mediafiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field


### PR DESCRIPTION
Além disso, adiciona a pasta onde os arquivos estáticos coletados são armazenados ao .gitignore.

[Close #47]